### PR TITLE
fix: use full options name for extra-index-url

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -67,7 +67,7 @@ To install the nightly version of your dependencies check which of them are avai
 at https://anaconda.org/scientific-python-nightly-wheels/. For example to install the NumPy and scipy nightlies use:
 
 ```
-python -m pip install --pre --upgrade --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
+python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
 ```
 
 Complete examples of how projects implement this in their CI setup are linked in the Notes section.


### PR DESCRIPTION
This is actually `--extra-index-url`, and pip happens to work if you shorten it due to argparse's horrible default (and before some version of python, only) of guessing arguments if they are not complete.

This will really hit someone if they transform it to an environment variable, like all pip options allow, and get a do-nothing `PIP_EXTRA_INDEX` instead of the correct `PIP_EXTRA_INDEX_URL` (which is what just happened to me before I realized the missing part of this option).